### PR TITLE
при попытке парсинга входных данных игнорируем все виды ошибок включая ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/kz/ncanode/api/version/v20/models/CmsSignModel.java
+++ b/src/main/java/kz/ncanode/api/version/v20/models/CmsSignModel.java
@@ -37,7 +37,7 @@ public class CmsSignModel extends ApiModel {
     protected void afterAccept() {
         try {
             this.signedData = new CMSSignedData(data.get());
-        } catch (CMSException ignored) {
+        } catch (Exception ignored) {
             // документ не подписан, это нормально
         }
     }


### PR DESCRIPTION
Получили ошибку
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
at kz.gov.pki.kalkan.jce.provider.cms.CMSSignedData.<init>(CMSSignedData.java:86)

Скорее всего ее нужно проигнорировать, т.к. это происходит в сценарии проверки, пришел ли на подпись уже подписанный файл. А он не подписан - это нормально.

